### PR TITLE
Release v0.5.1

### DIFF
--- a/source/Gexf.php
+++ b/source/Gexf.php
@@ -210,6 +210,7 @@ class Gexf
 
     /**
      * Prepare and store the XML string
+     * @throws \Exception
      */
     public function render()
     {
@@ -375,12 +376,12 @@ class Gexf
      */
     private function renderEdgeAttributes()
     {
-        return (count($this->edgeAttributeObjects))
+        return ($this->getEdgeAttributeObjects())
             ? implode([
                 '<attributes class="edge">',
-                implode(array_map(function ($GexfAttribute) {
+                implode(array_map(function (GexfAttribute $GexfAttribute) {
                     return $GexfAttribute->renderAttribute();
-                }, $this->edgeAttributeObjects)),
+                }, $this->getEdgeAttributeObjects())),
                 '</attributes>',
             ])
             : '';
@@ -406,27 +407,28 @@ class Gexf
 
     /**
      * @return string
+     * @throws \Exception
      */
     private function renderNodeAttributes()
     {
         $output = [];
 
-        if (count($this->nodeAttributeObjects[self::MODE_STATIC])) {
+        if (count($this->getNodeAttributeObjects(self::MODE_STATIC))) {
             $output[] = implode([
                 '<attributes class="node" mode="static">',
                 implode(array_map(function (GexfAttribute $GexfAttribute) {
                     return $GexfAttribute->renderAttribute();
-                }, $this->nodeAttributeObjects[self::MODE_STATIC])),
+                }, $this->getNodeAttributeObjects(self::MODE_STATIC))),
                 '</attributes>',
             ]);
         }
 
-        if (count($this->nodeAttributeObjects[self::MODE_DYNAMIC])) {
+        if (count($this->getNodeAttributeObjects(self::MODE_DYNAMIC))) {
             $output[] = implode([
                 '<attributes class="node" mode="dynamic">',
                 implode(array_map(function (GexfAttribute $GexfAttribute) {
                     return $GexfAttribute->renderAttribute();
-                }, $this->nodeAttributeObjects[self::MODE_DYNAMIC])),
+                }, $this->getNodeAttributeObjects(self::MODE_DYNAMIC))),
                 '</attributes>',
             ]);
         }

--- a/source/GexfAttribute.php
+++ b/source/GexfAttribute.php
@@ -335,7 +335,7 @@ class GexfAttribute
             }, $options);
         }
 
-        return $options;
+        return array_values($options);
     }
 
     /**

--- a/source/GexfAttribute.php
+++ b/source/GexfAttribute.php
@@ -348,7 +348,7 @@ class GexfAttribute
      */
     private function setId($forcedId = null)
     {
-        $this->id = (isset($forcedId)) ? $forcedId : 'a-' . md5($this->getName());
+        $this->id = (isset($forcedId)) ? Gexf::cleanseId($forcedId) : 'a-' . md5($this->getName());
 
         return $this;
     }

--- a/source/GexfNode.php
+++ b/source/GexfNode.php
@@ -259,9 +259,9 @@ class GexfNode
         return (count($this->getParentNodes()) > 1)
             ? implode([
                 '<parents>',
-                implode(array_filter(array_map(function ($parentNodeId) {
+                implode(array_map(function ($parentNodeId) {
                     return '<parent for="' . $parentNodeId . '"/>';
-                }, $this->getParentNodes()))),
+                }, $this->getParentNodes())),
                 '</parents>',
             ])
             : '';

--- a/source/traits/GexfCommonInnerElements.php
+++ b/source/traits/GexfCommonInnerElements.php
@@ -91,7 +91,7 @@ trait GexfCommonInnerElements
         return (count($this->getAttributes()))
             ? implode(array_filter([
                 '<attvalues>',
-                implode(array_map(function ($GexfAttribute) use (&$Gexf) {
+                implode(array_map(function (GexfAttribute $GexfAttribute) use (&$Gexf) {
 
                     if (is_a($this, GexfNode::class)) {
                         // Add it to the list for later


### PR DESCRIPTION
Minor cleanup and internal fixes
- Remove unnecessary array_filter call
 - Use getter methods for properties internally instead of accessing directly (dogfooding)
- Update phpdocs with some thrown exceptions after using getters
- Add Class Hints to Gexf-object parameters where missing
- Possibly missed a commit for #4 when pushing work for v0.5.0